### PR TITLE
Fix loading with riemann-wrapper

### DIFF
--- a/exe/riemann-opensearch
+++ b/exe/riemann-opensearch
@@ -4,4 +4,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require "riemann/tools/opensearch"
 
-Riemann::Tools::OpenSearch.run
+Riemann::Tools::Opensearch.run

--- a/lib/riemann/tools/opensearch.rb
+++ b/lib/riemann/tools/opensearch.rb
@@ -5,7 +5,7 @@ require "opensearch-ruby"
 
 module Riemann
   module Tools
-    class OpenSearch
+    class Opensearch
       class JsonMapper
         def initialize(values)
           values.each do |k, v|

--- a/spec/riemann/tools/opensearch_spec.rb
+++ b/spec/riemann/tools/opensearch_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Riemann::Tools::OpenSearch::Allocation do
+RSpec.describe Riemann::Tools::Opensearch::Allocation do
   subject do
     described_class.new(JSON.parse(<<~JSON))
       {
@@ -30,7 +30,7 @@ RSpec.describe Riemann::Tools::OpenSearch::Allocation do
   end
 end
 
-RSpec.describe Riemann::Tools::OpenSearch::Health do
+RSpec.describe Riemann::Tools::Opensearch::Health do
   subject do
     described_class.new(JSON.parse(<<~JSON))
       {


### PR DESCRIPTION
Because `OpenSearch` is converted to `open_search`, riemann-wrapper fail to auto-load this tool.

Rename it to allow loading from riemann-wrapper.
