### PR TITLE
Fix loading X.509 certificate / key

### DIFF
--- a/lib/riemann/tools/opensearch.rb
+++ b/lib/riemann/tools/opensearch.rb
@@ -84,8 +84,8 @@ module Riemann
           transport_options: {
             ssl: {
               ca_file: opts[:os_ca_cert],
-              client_cert: opts[:os_cert],
-              client_key: opts[:os_key],
+              client_cert: opts[:os_cert] && OpenSSL::X509::Certificate.new(File.read(opts[:os_cert])),
+              client_key: opts[:os_key] && OpenSSL::PKey.read(File.read(opts[:os_key])),
               verify: !opts[:os_insecure]
             }
           }


### PR DESCRIPTION
We must pass the actual `OpenSSL::Certificate` / `OpenSSL::Pkey` object to
Faraday.  We had local patches in production for some time but never
fixed the repository.
